### PR TITLE
fix(runtime): Missing `camel-jackson` dependency at runtime (#2)

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -58,13 +58,13 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-jackson</artifactId>
-      <scope>test</scope>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-jsonpath</artifactId>
-      <scope>test</scope>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This declares `camel-jackson` and `camel-jsonpath` as runtime dependencies, as they are currently needed at runtime.