### PR TITLE
refactor(filter): Filter use now always 'simple', not jsonpath

### DIFF
--- a/model/src/main/java/io/syndesis/integration/model/SyndesisHelpers.java
+++ b/model/src/main/java/io/syndesis/integration/model/SyndesisHelpers.java
@@ -49,14 +49,21 @@ public class SyndesisHelpers {
      * Tries to load the configuration file from the current directory
      */
     public static SyndesisModel load() throws IOException {
-        return findFromFolder(new File("."));
+        SyndesisModel model = tryFindFromFolder(new File("."));
+        if (model == null) {
+            model = tryFindConfigOnClassPath();
+            if (model != null) {
+                return model;
+            }
+        }
+        throw new IOException("syndesis.yml could not be found in current directory or parent directories and is not on the classpath");
     }
 
 
     protected static SyndesisModel loadFromFile(File file) throws IOException {
         LOG.debug("Parsing syndesis configuration from: " + file.getName());
         try {
-            SyndesisModel config = SyndesisHelpers.parseSyndesisConfig(file);
+            SyndesisModel config = parseSyndesisConfig(file);
             return validateConfig(config, file);
         } catch (IOException e) {
             throw new IOException("Failed to parse syndesis config: " + file + ". " + e, e);
@@ -92,34 +99,25 @@ public class SyndesisHelpers {
     /**
      * Tries to find the configuration from the current directory or a parent folder.
      */
-    public static SyndesisModel findFromFolder(File folder) throws IOException {
+    public static SyndesisModel tryFindFromFolder(File folder) throws IOException {
         if (folder.isDirectory()) {
-            File file = new File(folder, FILE_NAME);
-            if (file != null && file.exists() && file.isFile()) {
-                return loadFromFile(file);
+            for (File file : new File[] {
+                new File(folder, FILE_NAME),
+                new File(new File(folder, "config"), FILE_NAME)
+            }) {
+                if (file.exists() && file.isFile()) {
+                    return loadFromFile(file);
+                }
             }
-            File configFolder = new File(folder, "config");
-            file = new File(configFolder, FILE_NAME);
-            if (file != null && file.exists() && file.isFile()) {
-                return loadFromFile(file);
-            }
+
             File parentFile = folder.getParentFile();
             if (parentFile != null) {
-                return findFromFolder(parentFile);
+                return tryFindFromFolder(parentFile);
             }
-            SyndesisModel answer = tryFindConfigOnClassPath();
-            if (answer != null) {
-                return answer;
-            }
-            throw new IOException("SyndesisModel configuration file does not exist: " + file.getPath());
         } else if (folder.isFile()) {
             return loadFromFile(folder);
         }
-        SyndesisModel answer = tryFindConfigOnClassPath();
-        if (answer != null) {
-            return answer;
-        }
-        throw new IOException("SyndesisModel configuration folder does not exist: " + folder.getPath());
+        return null;
     }
 
     protected static SyndesisModel tryFindConfigOnClassPath() throws IOException {

--- a/model/src/main/java/io/syndesis/integration/model/steps/ChildSteps.java
+++ b/model/src/main/java/io/syndesis/integration/model/steps/ChildSteps.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Reuable base class for steps which contain nested steps
+ * Reusable base class for steps which contain nested steps
  */
 public abstract class ChildSteps<T extends ChildSteps> extends Step {
     protected List<Step> steps = new ArrayList<>();

--- a/model/src/test/java/io/syndesis/integration/model/ModelUnmarshalTest.java
+++ b/model/src/test/java/io/syndesis/integration/model/ModelUnmarshalTest.java
@@ -16,15 +16,16 @@
  */
 package io.syndesis.integration.model;
 
+import java.io.File;
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  */
@@ -33,9 +34,9 @@ public class ModelUnmarshalTest {
 
     @Test
     public void testUnarshal() throws Exception {
-        SyndesisModel config = SyndesisHelpers.tryFindFromFolder(getTestResources());
-        assertNotNull(config);
-        List<Flow> rules = config.getFlows();
+        Optional<SyndesisModel> config = SyndesisHelpers.tryFindFromFolder(getTestResources());
+        assertTrue(config.isPresent());
+        List<Flow> rules = config.get().getFlows();
         assertThat(rules).isNotEmpty();
 
         for (Flow rule : rules) {
@@ -43,8 +44,8 @@ public class ModelUnmarshalTest {
         }
 
 
-        Flow actualFlow1 = SyndesisAssertions.assertFlow(config, 0);
-        Flow actualFlow2 =  SyndesisAssertions.assertFlow(config, 1);
+        Flow actualFlow1 = SyndesisAssertions.assertFlow(config.get(), 0);
+        Flow actualFlow2 =  SyndesisAssertions.assertFlow(config.get(), 1);
 
 
         assertThat(actualFlow1.getName()).describedAs("name").isEqualTo("thingy");

--- a/model/src/test/java/io/syndesis/integration/model/ModelUnmarshalTest.java
+++ b/model/src/test/java/io/syndesis/integration/model/ModelUnmarshalTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
 
 /**
  */
@@ -32,7 +33,8 @@ public class ModelUnmarshalTest {
 
     @Test
     public void testUnarshal() throws Exception {
-        SyndesisModel config = SyndesisHelpers.findFromFolder(getTestResources());
+        SyndesisModel config = SyndesisHelpers.tryFindFromFolder(getTestResources());
+        assertNotNull(config);
         List<Flow> rules = config.getFlows();
         assertThat(rules).isNotEmpty();
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -68,6 +68,16 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring-boot</artifactId>
     </dependency>
@@ -132,11 +142,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/runtime/src/main/java/io/syndesis/integration/runtime/SyndesisRouteBuilder.java
+++ b/runtime/src/main/java/io/syndesis/integration/runtime/SyndesisRouteBuilder.java
@@ -53,6 +53,8 @@ import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
 
+import static java.util.Optional.ofNullable;
+
 /**
  * A Camel {@link RouteBuilder} which maps the SyndesisModel rules to Camel routes
  */
@@ -144,7 +146,7 @@ public class SyndesisRouteBuilder extends RouteBuilder {
                         uri += "?method=" + method;
                     }
                     route = fromOrTo(route, name, uri, message);
-                    message.append(functionName).append(".").append(method != null ? method : "main").append("()");
+                    message.append(functionName).append(".").append(ofNullable(method).orElse("main")).append("()");
                 }
             } else if (item instanceof Endpoint) {
                 Endpoint invokeEndpoint = (Endpoint) item;
@@ -238,7 +240,7 @@ public class SyndesisRouteBuilder extends RouteBuilder {
                     // lets add the HTTP endpoint prefix
 
                     // is there any context-path
-                    String path = stripPrefix(trigger, "https://","http://","http:","https:");
+                    String path = getWithoutPrefixIfItStartsWithPrefix(trigger, "https://", "http://", "http:", "https:");
                     if (path != null) {
                         // keep only context path
                         if (path.contains("/")) {
@@ -261,7 +263,7 @@ public class SyndesisRouteBuilder extends RouteBuilder {
         return route;
     }
 
-    private String stripPrefix(String trigger, String ... prefixes) {
+    private String getWithoutPrefixIfItStartsWithPrefix(String trigger, String ... prefixes) {
         for (String prefix : prefixes) {
             if (trigger.startsWith(prefix)) {
                 return trigger.substring(prefix.length());

--- a/runtime/src/main/java/io/syndesis/integration/runtime/stephandlers/ChoiceHandler.java
+++ b/runtime/src/main/java/io/syndesis/integration/runtime/stephandlers/ChoiceHandler.java
@@ -39,7 +39,7 @@ public class ChoiceHandler implements StepHandler<Choice> {
     ChoiceDefinition choice = route.choice();
     List<Filter> filters = notNullList(step.getFilters());
     for (Filter filter : filters) {
-      Predicate predicate = routeBuilder.getMandatoryPredicate(filter, filter.getExpression());
+      Predicate predicate = routeBuilder.getMandatorySimplePredicate(filter, filter.getExpression());
       ChoiceDefinition when = choice.when(predicate);
       route = routeBuilder.addSteps(when, filter.getSteps());
     }

--- a/runtime/src/main/java/io/syndesis/integration/runtime/stephandlers/FilterHandler.java
+++ b/runtime/src/main/java/io/syndesis/integration/runtime/stephandlers/FilterHandler.java
@@ -24,15 +24,16 @@ import org.apache.camel.model.ProcessorDefinition;
 
 @AutoService(StepHandler.class)
 public class FilterHandler implements StepHandler<Filter> {
-  @Override
-  public boolean canHandle(Step step) {
-    return step.getClass().equals(Filter.class);
-  }
+    @Override
+    public boolean canHandle(Step step) {
+        return step.getClass().equals(Filter.class);
+    }
 
   @Override
   public ProcessorDefinition handle(Filter step, ProcessorDefinition route, SyndesisRouteBuilder routeBuilder) {
-    Predicate predicate = routeBuilder.getMandatoryPredicate(step, step.getExpression());
+    Predicate predicate = routeBuilder.getMandatorySimplePredicate(step, step.getExpression());
     FilterDefinition filter = route.filter(predicate);
     return routeBuilder.addSteps(filter, step.getSteps());
   }
 }
+

--- a/runtime/src/main/java/io/syndesis/integration/runtime/util/JsonSimplePredicate.java
+++ b/runtime/src/main/java/io/syndesis/integration/runtime/util/JsonSimplePredicate.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.integration.runtime.util;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.Exchange;
+import org.apache.camel.Predicate;
+import org.apache.camel.model.ModelCamelContext;
+import org.apache.camel.spi.Language;
+import org.apache.camel.spi.Registry;
+import org.apache.camel.util.ExchangeHelper;
+
+/**
+ * Predicate which tries to convert a JSON message to a map first before
+ * applying
+ */
+public class JsonSimplePredicate implements Predicate {
+    private final Predicate simpleExpression;
+
+    public JsonSimplePredicate(String expression, ModelCamelContext context) {
+        Language language = context.resolveLanguage("simple");
+        Objects.requireNonNull(language, "The language 'simple' could not be resolved!");
+            simpleExpression = language.createPredicate(expression);
+    }
+
+    @Override
+    public boolean matches(Exchange exchange) {
+        Object msgBody = exchange.getIn().getBody();
+        Exchange exchangeToCheck = exchange;
+
+        // TODO: Maybe check for content-type, too ?
+        // String contentType = exchange.getIn().getHeader(Exchange.CONTENT_TYPE, String.class);
+        // if ("application/json".equals(contentType)) { ... }
+        // ???
+        if (msgBody instanceof String) {
+            // If it is a json document , suppose that this is a document which needs to be parsed as JSON
+            // Therefor we set a map instead of the string
+            Map jsonDocument = jsonStringAsMap((String) msgBody, exchange);
+            if (jsonDocument != null) {
+                exchangeToCheck = ExchangeHelper.createCopy(exchange, true);
+                exchangeToCheck.getIn().setBody(jsonDocument);
+            }
+        }
+        return simpleExpression.matches(exchangeToCheck);
+    }
+
+    private Map jsonStringAsMap(String body, Exchange exchange) {
+        ObjectMapper mapper = resolveObjectMapper(exchange.getContext().getRegistry());
+
+        // convert JSON string to Map
+        try {
+            return mapper.readValue(body, new TypeReference<Map<String, Object>>(){});
+        } catch (IOException e) {
+            // ignore because we are attempting to convert, but its not a JSON document
+        }
+        return null;
+    }
+
+    private ObjectMapper resolveObjectMapper(Registry registry) {
+        Set<ObjectMapper> mappers = registry.findByType(ObjectMapper.class);
+        if (mappers.size() == 1) {
+            return mappers.iterator().next();
+        }
+        return new ObjectMapper();
+    }
+}

--- a/runtime/src/main/java/io/syndesis/integration/runtime/util/JsonSimplePredicate.java
+++ b/runtime/src/main/java/io/syndesis/integration/runtime/util/JsonSimplePredicate.java
@@ -54,6 +54,10 @@ public class JsonSimplePredicate implements Predicate {
             // Therefor we set a map instead of the string
             Map jsonDocument = jsonStringAsMap((String) msgBody, exchange);
             if (jsonDocument != null) {
+                // Clone the exchange and set the JSON message converted to a Map / List as in message.
+                // The intention is that only this predicate acts on the converted value,
+                // but the original in-message still continues to carry the same format
+                // The predicated is supposed to be read only with respect to the incoming messaeg.
                 exchangeToCheck = ExchangeHelper.createCopy(exchange, true);
                 exchangeToCheck.getIn().setBody(jsonDocument);
             }

--- a/runtime/src/test/java/io/syndesis/integration/runtime/steps/ChoiceTest.java
+++ b/runtime/src/test/java/io/syndesis/integration/runtime/steps/ChoiceTest.java
@@ -89,8 +89,8 @@ public class ChoiceTest extends SyndesisTestSupport {
     protected void addSyndesisFlows(SyndesisModel syndesis) {
         Flow flow = syndesis.createFlow().endpoint(START_URI);
         Choice choice = flow.choice();
-        choice.when("$.[?(@.name == 'James')]").endpoint(MATCHED_JAMES_URI);
-        choice.when("$.[?(@.name == 'Jimmi')]").endpoint(MATCHED_JIMMI_URI);
+        choice.when("${body[name]} == 'James'").endpoint(MATCHED_JAMES_URI);
+        choice.when("${body[name]} == 'Jimmi'").endpoint(MATCHED_JIMMI_URI);
         choice.otherwise().endpoint(OTHERWISE_URI);
         flow.endpoint(ALL_MESSAGES_URI);
     }

--- a/runtime/src/test/java/io/syndesis/integration/runtime/steps/FilterTest.java
+++ b/runtime/src/test/java/io/syndesis/integration/runtime/steps/FilterTest.java
@@ -20,6 +20,7 @@ import io.syndesis.integration.SyndesisTestSupport;
 import io.syndesis.integration.model.Flow;
 import io.syndesis.integration.model.SyndesisModel;
 import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -72,7 +73,7 @@ public class FilterTest extends SyndesisTestSupport {
     @Override
     protected void addSyndesisFlows(SyndesisModel syndesis) {
         Flow flow = syndesis.createFlow().endpoint(START_URI);
-        flow.filter("$.[?(@.name == 'James')]").endpoint(MATCHED_URI);
+        flow.filter("${body[name]} == 'James'").endpoint(MATCHED_URI);
         flow.endpoint(ALL_MESSAGES_URI);
     }
 }

--- a/runtime/src/test/resources/io/syndesis/integration/runtime/steps/ChoiceYamlTest-testStep.yml
+++ b/runtime/src/test/resources/io/syndesis/integration/runtime/steps/ChoiceYamlTest-testStep.yml
@@ -20,12 +20,12 @@ flows:
   - kind: "choice"
     filters:
     - kind: "filter"
-      expression: "$.[?(@.name == 'James')]"
+      expression: "${body[name]} == 'James'"
       steps:
       - kind: "endpoint"
         uri: "mock:matchedJames"
     - kind: "filter"
-      expression: "$.[?(@.name == 'Jimmi')]"
+      expression: "${body[name]} == 'Jimmi'"
       steps:
       - kind: "endpoint"
         uri: "mock:matchedJimmi"

--- a/runtime/src/test/resources/io/syndesis/integration/runtime/steps/FilterYamlTest-testStep.yml
+++ b/runtime/src/test/resources/io/syndesis/integration/runtime/steps/FilterYamlTest-testStep.yml
@@ -18,7 +18,7 @@ flows:
   - kind: "endpoint"
     uri: "direct:start"
   - kind: "filter"
-    expression: "$.[?(@.name == 'James')]"
+    expression: "${body[name]} == 'James'"
     steps:
     - kind: "endpoint"
       uri: "mock:matched"


### PR DESCRIPTION
A JsonSimplePredicate has been introduced which temporarily tries to convert a string to a JSON map / list so that the simple language expression can be applied to it.