### PR TITLE
fix(filter): Convert simple expression on the fly to an OGNL path for JSON

### DIFF
--- a/runtime/src/test/java/io/syndesis/integration/runtime/steps/FilterTest.java
+++ b/runtime/src/test/java/io/syndesis/integration/runtime/steps/FilterTest.java
@@ -73,7 +73,7 @@ public class FilterTest extends SyndesisTestSupport {
     @Override
     protected void addSyndesisFlows(SyndesisModel syndesis) {
         Flow flow = syndesis.createFlow().endpoint(START_URI);
-        flow.filter("${body[name]} == 'James'").endpoint(MATCHED_URI);
+        flow.filter("${body.name} == 'James'").endpoint(MATCHED_URI);
         flow.endpoint(ALL_MESSAGES_URI);
     }
 }

--- a/runtime/src/test/resources/io/syndesis/integration/runtime/steps/FilterYamlTest-testStep.yml
+++ b/runtime/src/test/resources/io/syndesis/integration/runtime/steps/FilterYamlTest-testStep.yml
@@ -18,7 +18,7 @@ flows:
   - kind: "endpoint"
     uri: "direct:start"
   - kind: "filter"
-    expression: "${body[name]} == 'James'"
+    expression: "${body.name} == 'James'"
     steps:
     - kind: "endpoint"
       uri: "mock:matched"


### PR DESCRIPTION
This could be improved to convert to reall jsonpath for json documents.
Its still not super clear when to detect that JSON is going through the
route or an object. Currently its just checked for a String
but obviously somehting like a ContentType Header would make much sense, too.