### PR TITLE
chore: Upgrade Camel to 2.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,20 +75,50 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <camel.version>2.19.0</camel.version>
-    <jackson.version>2.8.8</jackson.version>
+    <camel.version>2.20.0.fuse-000093</camel.version>
+    <jackson.version>2.8.9</jackson.version>
     <assertj.version>2.4.1</assertj.version>
     <rest-assured.version>3.0.0</rest-assured.version>
-    <spring-boot.version>1.5.3.RELEASE</spring-boot.version>
-    <spring-boot-plugin.version>1.5.3.RELEASE</spring-boot-plugin.version>
+    <spring-boot.version>1.5.6.RELEASE</spring-boot.version>
+    <spring-boot-plugin.version>1.5.7.RELEASE</spring-boot-plugin.version>
     <dep.plugin.dependency.version>3.0.1</dep.plugin.dependency.version>
     <auto-service.version>1.0-rc3</auto-service.version>
+    <json-path.version>2.4.0</json-path.version>
+    <spring.version>4.3.11.RELEASE</spring.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <basepom.test.timeout>180</basepom.test.timeout>
     <basepom.failsafe.timeout>180</basepom.failsafe.timeout>
   </properties>
+
+  <repositories>
+    <repository>
+      <id>jboss-ea</id>
+      <name>JBoss Early-access repository</name>
+      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>jboss-ea</id>
+      <name>JBoss Early-access repository</name>
+      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
 
   <modules>
     <module>model</module>
@@ -128,9 +158,39 @@
       </dependency>
 
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-beans</artifactId>
+        <version>${spring.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-expression</artifactId>
+        <version>${spring.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-tx</artifactId>
+        <version>${spring.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-aop</artifactId>
+        <version>${spring.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.google.auto.service</groupId>
         <artifactId>auto-service</artifactId>
         <version>${auto-service.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.jayway.jsonpath</groupId>
+        <artifactId>json-path</artifactId>
+        <version>${json-path.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This upgrades Camel to 2.20 and aligns the versions of dependencies that
it depends upon.

Fixes #14