### PR TITLE
chore: upgrade Camel to 2.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <camel.version>2.20.0.fuse-000101</camel.version>
-    <jackson.version>2.8.9</jackson.version>
+    <camel.version>2.20.0</camel.version>
+    <jackson.version>2.8.10</jackson.version>
     <assertj.version>2.4.1</assertj.version>
     <rest-assured.version>3.0.0</rest-assured.version>
     <spring-boot.version>1.5.6.RELEASE</spring-boot.version>
@@ -91,34 +91,6 @@
     <basepom.test.timeout>180</basepom.test.timeout>
     <basepom.failsafe.timeout>180</basepom.failsafe.timeout>
   </properties>
-
-  <repositories>
-    <repository>
-      <id>jboss-ea</id>
-      <name>JBoss Early-access repository</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>jboss-ea</id>
-      <name>JBoss Early-access repository</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
 
   <modules>
     <module>model</module>


### PR DESCRIPTION
This upgrades Camel to 2.20.0 and removes the Fuse EA repositories.